### PR TITLE
Fix gNMIc config target port config

### DIFF
--- a/configs/gnmic/gnmic-config.yml
+++ b/configs/gnmic/gnmic-config.yml
@@ -6,7 +6,6 @@ username: admin
 timeout: 10s
 
 common_srl_subscriptions: &common_srl_subs
-  port: 57400
   skip-verify: true
   insecure: false
   password: NokiaSrl1!
@@ -20,11 +19,11 @@ common_srl_subscriptions: &common_srl_subs
     - srl-net-instance
 
 targets:
-  leaf1: *common_srl_subs
-  leaf2: *common_srl_subs
-  leaf3: *common_srl_subs
-  spine1: *common_srl_subs
-  spine2: *common_srl_subs
+  leaf1:57400: *common_srl_subs
+  leaf2:57400: *common_srl_subs
+  leaf3:57400: *common_srl_subs
+  spine1:57400: *common_srl_subs
+  spine2:57400: *common_srl_subs
 
 subscriptions:
   srl-system-performance:


### PR DESCRIPTION
This is the correct syntax for setting the target node's gNMI port, the current syntax is wrong (and it only worked because the default gNMI port was used in this topology).