### PR TITLE
revert #52 to resurrect the dashboards

### DIFF
--- a/configs/gnmic/gnmic-config.yml
+++ b/configs/gnmic/gnmic-config.yml
@@ -19,11 +19,11 @@ common_srl_subscriptions: &common_srl_subs
     - srl-net-instance
 
 targets:
-  leaf1:57400: *common_srl_subs
-  leaf2:57400: *common_srl_subs
-  leaf3:57400: *common_srl_subs
-  spine1:57400: *common_srl_subs
-  spine2:57400: *common_srl_subs
+  leaf1: *common_srl_subs
+  leaf2: *common_srl_subs
+  leaf3: *common_srl_subs
+  spine1: *common_srl_subs
+  spine2: *common_srl_subs
 
 subscriptions:
   srl-system-performance:


### PR DESCRIPTION
reverting #52 since the proper fix requires to add ports (as originally done in #52) to the target names and

1. regenerate the svg as the IDs are kept in there
2. change the frontpanel config to use the changed names


/cc @aaakpinar @vista- @dhaene @zenodhaene