### PR TITLE
update srl model names + add topo coordinates

### DIFF
--- a/st.clab.yml
+++ b/st.clab.yml
@@ -16,19 +16,19 @@ topology:
   kinds:
     nokia_srlinux:
       image: ghcr.io/nokia/srlinux:24.10.1
-      type: ixrd2l
+      type: ixr-d2l
     linux:
       image: ghcr.io/srl-labs/network-multitool
 
   nodes:
     ### SPINES ###
     spine1:
-      type: ixrd3l
+      type: ixr-d3l
       group: spine
       startup-config: configs/fabric/spine1.cfg
       mgmt-ipv4: 172.80.80.21
     spine2:
-      type: ixrd3l
+      type: ixr-d3l
       group: spine
       startup-config: configs/fabric/spine2.cfg
       mgmt-ipv4: 172.80.80.22

--- a/st.clab.yml.annotations.json
+++ b/st.clab.yml.annotations.json
@@ -1,0 +1,163 @@
+{
+  "freeTextAnnotations": [],
+  "groupStyleAnnotations": [],
+  "cloudNodeAnnotations": [],
+  "nodeAnnotations": [
+    {
+      "id": "spine1",
+      "icon": "router",
+      "position": {
+        "x": 77,
+        "y": 91
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "spine2",
+      "icon": "router",
+      "position": {
+        "x": 189,
+        "y": 91
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "leaf1",
+      "icon": "router",
+      "position": {
+        "x": 35,
+        "y": 147
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "leaf2",
+      "icon": "router",
+      "position": {
+        "x": 133,
+        "y": 147
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "leaf3",
+      "icon": "router",
+      "position": {
+        "x": 231,
+        "y": 147
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "client1",
+      "icon": "router",
+      "position": {
+        "x": 35,
+        "y": 217
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "client2",
+      "icon": "router",
+      "position": {
+        "x": 133,
+        "y": 217
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "client3",
+      "icon": "router",
+      "position": {
+        "x": 231,
+        "y": 217
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "gnmic",
+      "icon": "router",
+      "position": {
+        "x": 21,
+        "y": 49
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "prometheus",
+      "icon": "router",
+      "position": {
+        "x": 77,
+        "y": 49
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "grafana",
+      "icon": "router",
+      "position": {
+        "x": 245,
+        "y": 49
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "promtail",
+      "icon": "router",
+      "position": {
+        "x": 133,
+        "y": 49
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    },
+    {
+      "id": "loki",
+      "icon": "router",
+      "position": {
+        "x": 189,
+        "y": 49
+      },
+      "geoCoordinates": {
+        "lat": 48.684826888402256,
+        "lng": 9.007895390625677
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR is to fix the Warnings bellow


```
[*]─[C-PF4NF347]─[~/srx/srl-telemetry-lab]
└──> clab inspect -t st.clab.yml
12:03:29 INFO Parsing & checking topology file=st.clab.yml
12:03:29 WARN Deprecation notice
  notice=
  │ You are using a deprecated SR Linux node type name. Consider using a new format with dashes. Example: ixr-d2l, ixr-h5-64d, etc.
  │ Deprecated type format will be removed after January 2026
 deprecated type=ixrd2l
12:03:29 WARN Deprecation notice
  notice=
  │ You are using a deprecated SR Linux node type name. Consider using a new format with dashes. Example: ixr-d2l, ixr-h5-64d, etc.
  │ Deprecated type format will be removed after January 2026
 deprecated type=ixrd2l
12:03:29 WARN Deprecation notice
  notice=
  │ You are using a deprecated SR Linux node type name. Consider using a new format with dashes. Example: ixr-d2l, ixr-h5-64d, etc.
  │ Deprecated type format will be removed after January 2026
 deprecated type=ixrd2l
12:03:29 WARN Deprecation notice
  notice=
  │ You are using a deprecated SR Linux node type name. Consider using a new format with dashes. Example: ixr-d2l, ixr-h5-64d, etc.
  │ Deprecated type format will be removed after January 2026
 deprecated type=ixrd3l
12:03:29 WARN Deprecation notice
  notice=
  │ You are using a deprecated SR Linux node type name. Consider using a new format with dashes. Example: ixr-d2l, ixr-h5-64d, etc.
  │ Deprecated type format will be removed after January 2026
 deprecated type=ixrd3l
╭────────────┬───────────────────────────────────────┬─────────┬────────────────╮
│    Name    │               Kind/Image              │  State  │ IPv4/6 Address │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ client1    │ linux                                 │ running │ 172.80.80.31   │
│            │ ghcr.io/srl-labs/network-multitool    │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ client2    │ linux                                 │ running │ 172.80.80.32   │
│            │ ghcr.io/srl-labs/network-multitool    │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ client3    │ linux                                 │ running │ 172.80.80.33   │
│            │ ghcr.io/srl-labs/network-multitool    │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ gnmic      │ linux                                 │ running │ 172.80.80.41   │
│            │ ghcr.io/openconfig/gnmic:0.39.1       │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ grafana    │ linux                                 │ running │ 172.80.80.43   │
│            │ grafana/grafana:11.2.0                │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ leaf1      │ nokia_srlinux                         │ running │ 172.80.80.11   │
│            │ ghcr.io/nokia/srlinux:24.10.1         │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ leaf2      │ nokia_srlinux                         │ running │ 172.80.80.12   │
│            │ ghcr.io/nokia/srlinux:24.10.1         │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ leaf3      │ nokia_srlinux                         │ running │ 172.80.80.13   │
│            │ ghcr.io/nokia/srlinux:24.10.1         │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ loki       │ linux                                 │ running │ 172.80.80.46   │
│            │ grafana/loki:3.2.0                    │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ prometheus │ linux                                 │ running │ 172.80.80.42   │
│            │ quay.io/prometheus/prometheus:v2.54.1 │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ promtail   │ linux                                 │ running │ 172.80.80.45   │
│            │ grafana/promtail:3.2.0                │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ spine1     │ nokia_srlinux                         │ running │ 172.80.80.21   │
│            │ ghcr.io/nokia/srlinux:24.10.1         │         │ N/A            │
├────────────┼───────────────────────────────────────┼─────────┼────────────────┤
│ spine2     │ nokia_srlinux                         │ running │ 172.80.80.22   │
│            │ ghcr.io/nokia/srlinux:24.10.1         │         │ N/A            │
╰────────────┴───────────────────────────────────────┴─────────┴────────────────╯

[*]─[C-PF4NF347]─[~/srx/srl-telemetry-lab]
```